### PR TITLE
#2 Make treatment of stub property values as regex optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ values: GET, POST (coming more in future).
 `type` type: String, value: fantasy <-- this property matches the query parameter `type`. `fantasy` value will match 
 `?type=fantasy` requests
 
+You may also use regular expression patterns as the value of the property. To indicate that the value of a specific
+property should be treated as a regex pattern and matched against the value of the named URL query parameter, you must
+add the ".regex" suffix to the property name:
+
+`type.regex` type: String, value: ^hist.*$ <-- this property matches the query parameter `type`. `^hist.*$` value
+will match both `?type=history` or `?type=historical fiction` requests.
+
 ![add_resource node](docs/demo/get-fantasy.png)
 
 Save the changes.

--- a/core/src/main/java/io/wttech/stubway/StubConstants.java
+++ b/core/src/main/java/io/wttech/stubway/StubConstants.java
@@ -1,5 +1,7 @@
 package io.wttech.stubway;
 
+import java.util.regex.Pattern;
+
 public class StubConstants {
 
 	public static final String STUB_RESOURCE_TYPE = "stubway/stub";
@@ -7,7 +9,7 @@ public class StubConstants {
 	public static final String NAMESPACE = "stub.";
 	public static final String STATUS_CODE = NAMESPACE + "statusCode";
 	public static final String METHOD = NAMESPACE + "method";
-	public static final String LITERAL = NAMESPACE + "literal";
+	public static final String REGEX_SUFFIX = ".regex";
 
 	private StubConstants() {
 		throw new IllegalStateException("Utility class");

--- a/core/src/main/java/io/wttech/stubway/StubConstants.java
+++ b/core/src/main/java/io/wttech/stubway/StubConstants.java
@@ -7,6 +7,7 @@ public class StubConstants {
 	public static final String NAMESPACE = "stub.";
 	public static final String STATUS_CODE = NAMESPACE + "statusCode";
 	public static final String METHOD = NAMESPACE + "method";
+	public static final String LITERAL = NAMESPACE + "literal";
 
 	private StubConstants() {
 		throw new IllegalStateException("Utility class");

--- a/core/src/main/java/io/wttech/stubway/matcher/QueryParametersMatcher.java
+++ b/core/src/main/java/io/wttech/stubway/matcher/QueryParametersMatcher.java
@@ -12,7 +12,7 @@ class QueryParametersMatcher extends AbstractMatcher {
 	@Override
 	protected Set<StubProperty> collectProperties(RequestParameters request) {
 		return request.getQueryParameters().stream()
-				.map(p -> StubProperty.create(p.getName(), p.getValue().split(",")))
+				.map(p -> StubProperty.create(p.getName(), p.getValue().split(","), false))
 				.flatMap(Collection::stream).collect(Collectors.toSet());
 	}
 

--- a/core/src/main/java/io/wttech/stubway/matcher/RequestBodyMatcher.java
+++ b/core/src/main/java/io/wttech/stubway/matcher/RequestBodyMatcher.java
@@ -27,7 +27,7 @@ class RequestBodyMatcher extends AbstractMatcher {
 				.map(JsonElement::getAsString)
 				.orElse(StringUtils.EMPTY);
 
-		return StubProperty.create(entry.getKey(), value);
+		return StubProperty.create(entry.getKey(), value, false);
 	}
 
 }

--- a/core/src/main/java/io/wttech/stubway/stub/Stub.java
+++ b/core/src/main/java/io/wttech/stubway/stub/Stub.java
@@ -5,7 +5,6 @@ import io.wttech.stubway.request.MissingSupportedMethodException;
 
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,8 +45,7 @@ public class Stub {
 		this.stubProperties = valueMap.keySet().stream()
 				.filter(key -> !key.startsWith(StubConstants.JCR_NAMESPACE))
 				.filter(key -> !key.startsWith(StubConstants.NAMESPACE))
-				.map(key -> StubProperty.create(key, valueMap.get(key, String[].class)))
-				.flatMap(Collection::stream)
+				.map(key -> StubProperty.create(key, valueMap.get(key, String[].class))).flatMap(Collection::stream)
 				.collect(Collectors.toSet());
 	}
 

--- a/core/src/main/java/io/wttech/stubway/stub/Stub.java
+++ b/core/src/main/java/io/wttech/stubway/stub/Stub.java
@@ -43,11 +43,10 @@ public class Stub {
 	@PostConstruct
 	private void afterCreated() {
 		ValueMap valueMap = resource.getValueMap();
-		Set<String> literalProperties = valueMap.get(StubConstants.LITERAL, Set.class);
 		this.stubProperties = valueMap.keySet().stream()
 				.filter(key -> !key.startsWith(StubConstants.JCR_NAMESPACE))
 				.filter(key -> !key.startsWith(StubConstants.NAMESPACE))
-				.map(key -> StubProperty.create(key, valueMap.get(key, String[].class), literalProperties.contains(key)))
+				.map(key -> StubProperty.create(key, valueMap.get(key, String[].class)))
 				.flatMap(Collection::stream)
 				.collect(Collectors.toSet());
 	}

--- a/core/src/main/java/io/wttech/stubway/stub/Stub.java
+++ b/core/src/main/java/io/wttech/stubway/stub/Stub.java
@@ -5,6 +5,7 @@ import io.wttech.stubway.request.MissingSupportedMethodException;
 
 import java.io.InputStream;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,10 +43,12 @@ public class Stub {
 	@PostConstruct
 	private void afterCreated() {
 		ValueMap valueMap = resource.getValueMap();
+		Set<String> literalProperties = valueMap.get(StubConstants.LITERAL, Set.class);
 		this.stubProperties = valueMap.keySet().stream()
 				.filter(key -> !key.startsWith(StubConstants.JCR_NAMESPACE))
 				.filter(key -> !key.startsWith(StubConstants.NAMESPACE))
-				.map(key -> StubProperty.create(key, valueMap.get(key, String[].class))).flatMap(Collection::stream)
+				.map(key -> StubProperty.create(key, valueMap.get(key, String[].class), literalProperties.contains(key)))
+				.flatMap(Collection::stream)
 				.collect(Collectors.toSet());
 	}
 

--- a/core/src/main/java/io/wttech/stubway/stub/StubProperty.java
+++ b/core/src/main/java/io/wttech/stubway/stub/StubProperty.java
@@ -5,6 +5,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import io.wttech.stubway.StubConstants;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 
@@ -18,16 +20,20 @@ public class StubProperty {
 		return create(name, value, false);
 	}
 
-	public static StubProperty create(String name, String value, boolean literal) {
-		return new StubProperty(name, literal ? Pattern.quote(value) : value);
+	public static StubProperty create(String name, String value, boolean quote) {
+		return new StubProperty(name, quote ? Pattern.quote(value) : value);
+	}
+
+	public static Set<StubProperty> create(String name, String[] value, boolean quote) {
+		return Stream.of(value).map(v -> create(name, v, quote)).collect(Collectors.toSet());
 	}
 
 	public static Set<StubProperty> create(String name, String[] value) {
-		return  create(name, value, false);
-	}
+		String realName = StringUtils.removeEnd(name, StubConstants.REGEX_SUFFIX);
 
-	public static Set<StubProperty> create(String name, String[] value, boolean literal) {
-		return  Stream.of(value).map(v -> create(name, v, literal)).collect(Collectors.toSet());
+		return Stream.of(value)
+				.map(v -> create(realName, v, realName.length() == name.length()))
+				.collect(Collectors.toSet());
 	}
 
 	private StubProperty(String name, String value) {

--- a/core/src/main/java/io/wttech/stubway/stub/StubProperty.java
+++ b/core/src/main/java/io/wttech/stubway/stub/StubProperty.java
@@ -1,6 +1,7 @@
 package io.wttech.stubway.stub;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -14,11 +15,19 @@ public class StubProperty {
 	private String value;
 
 	public static StubProperty create(String name, String value) {
-		return new StubProperty(name, value);
+		return create(name, value, false);
+	}
+
+	public static StubProperty create(String name, String value, boolean literal) {
+		return new StubProperty(name, literal ? Pattern.quote(value) : value);
 	}
 
 	public static Set<StubProperty> create(String name, String[] value) {
-		return Stream.of(value).map(v -> create(name, v)).collect(Collectors.toSet());
+		return  create(name, value, false);
+	}
+
+	public static Set<StubProperty> create(String name, String[] value, boolean literal) {
+		return  Stream.of(value).map(v -> create(name, v, literal)).collect(Collectors.toSet());
 	}
 
 	private StubProperty(String name, String value) {

--- a/core/src/main/java/io/wttech/stubway/stub/StubProperty.java
+++ b/core/src/main/java/io/wttech/stubway/stub/StubProperty.java
@@ -16,10 +16,6 @@ public class StubProperty {
 
 	private String value;
 
-	public static StubProperty create(String name, String value) {
-		return create(name, value, false);
-	}
-
 	public static StubProperty create(String name, String value, boolean quote) {
 		return new StubProperty(name, quote ? Pattern.quote(value) : value);
 	}

--- a/stubway.tests/src/test/java/io/wttech/stubway/StubTests.java
+++ b/stubway.tests/src/test/java/io/wttech/stubway/StubTests.java
@@ -115,6 +115,13 @@ public class StubTests {
 	}
 
 	@Test
+	public void getAllBooksTest() throws IOException {
+		Response response = this.sendGetRequest("/content/stubway/stubs/library/books?type=.*");
+		response.then().statusCode(200);
+		compareJsonResponse("all_get.json", response);
+	}
+
+	@Test
 	public void postFantasyBookTest() throws IOException {
 		String body = "{" + "type: fantasy" + "}";
 		Response response = sendPostRequest("/content/stubway/stubs/library/books", body);
@@ -136,6 +143,14 @@ public class StubTests {
 		Response response = sendPostRequest("/content/stubway/stubs/library/books", body);
 		response.then().statusCode(401);
 		compareJsonResponse("secret_post.json", response);
+	}
+
+	@Test
+	public void postAllBookTest() throws IOException {
+		String body = "{" + "type: .*" + "}";
+		Response response = sendPostRequest("/content/stubway/stubs/library/books", body);
+		response.then().statusCode(200);
+		compareJsonResponse("all_post.json", response);
 	}
 
 	@Test

--- a/stubway.tests/src/test/resources/io/wttech/stubway/all_get.json
+++ b/stubway.tests/src/test/resources/io/wttech/stubway/all_get.json
@@ -1,0 +1,45 @@
+{
+    "nbrOfBooks" : "10",
+    "books" : [
+        {
+            "author" : "Author 1",
+            "title" : "Fantasy Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Fantasy Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Fantasy Title 3"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Historical Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Historical Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Historical Title 3"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Poetry Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Poetry Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Poetry Title 3"
+        },
+        {
+            "author" : "Author 4",
+            "title" : "Poetry Title 4"
+        }
+    ]
+}

--- a/stubway.tests/src/test/resources/io/wttech/stubway/all_post.json
+++ b/stubway.tests/src/test/resources/io/wttech/stubway/all_post.json
@@ -1,0 +1,49 @@
+{
+    "nbrOfBooks" : "11",
+    "books" : [
+        {
+            "author" : "Author 1",
+            "title" : "Fantasy Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Fantasy Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Fantasy Title 3"
+        },
+        {
+            "author" : "Author 4",
+            "title" : "Fantasy Title 4"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Historical Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Historical Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Historical Title 3"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Poetry Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Poetry Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Poetry Title 3"
+        },
+        {
+            "author" : "Author 4",
+            "title" : "Poetry Title 4"
+        }
+    ]
+}

--- a/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-all.json
+++ b/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-all.json
@@ -1,0 +1,45 @@
+{
+    "nbrOfBooks" : "10",
+    "books" : [
+        {
+            "author" : "Author 1",
+            "title" : "Fantasy Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Fantasy Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Fantasy Title 3"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Historical Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Historical Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Historical Title 3"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Poetry Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Poetry Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Poetry Title 3"
+        },
+        {
+            "author" : "Author 4",
+            "title" : "Poetry Title 4"
+        }
+    ]
+}

--- a/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-all.json.dir/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-all.json.dir/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:mixinTypes="[cq:ComponentMixin]"
+    jcr:primaryType="nt:file"
+    stub.method="GET"
+    type=".*"/>

--- a/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-historical.json.dir/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-historical.json.dir/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
 	xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:mixinTypes="[cq:ComponentMixin]" jcr:primaryType="nt:file"
-	type="^hist.*$" stub.method="GET">
+	type.regex="^hist.*$" stub.method="GET">
 </jcr:root>

--- a/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/post-all.json
+++ b/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/post-all.json
@@ -1,0 +1,49 @@
+{
+    "nbrOfBooks" : "11",
+    "books" : [
+        {
+            "author" : "Author 1",
+            "title" : "Fantasy Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Fantasy Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Fantasy Title 3"
+        },
+        {
+            "author" : "Author 4",
+            "title" : "Fantasy Title 4"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Historical Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Historical Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Historical Title 3"
+        },
+        {
+            "author" : "Author 1",
+            "title" : "Poetry Title 1"
+        },
+        {
+            "author" : "Author 2",
+            "title" : "Poetry Title 2"
+        },
+        {
+            "author" : "Author 3",
+            "title" : "Poetry Title 3"
+        },
+        {
+            "author" : "Author 4",
+            "title" : "Poetry Title 4"
+        }
+    ]
+}

--- a/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/post-all.json.dir/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/post-all.json.dir/.content.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:mixinTypes="[cq:ComponentMixin]"
+    jcr:primaryType="nt:file"
+    stub.method="POST"
+    type=".*"/>


### PR DESCRIPTION
Issue : #2

## Description
- Add support for "stub.literal" property, which should list the names
  of the properties that should be treated as literal values

- Quote property values that should be treated as literal strings when
creating StubProperty objects that will be used for matching

- Default behavior is to treat values as regex for back compatibility

## Types of Changes
- New feature (non-breaking change which adds functionality)

## Tasks
- [x] Agree on new property name
- [x] Documentation

## Review
- [x] Tests
- [x] Documentation

## Deployment Notes
- New optional "stub.literal" property, which defaults to "false" for all properties.