### PR TITLE
Add support for response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ add the ".regex" suffix to the property name:
 `type.regex` type: String, value: ^hist.*$ <-- this property matches the query parameter `type`. `^hist.*$` value
 will match both `?type=history` or `?type=historical fiction` requests.
 
+You also have the option to specify values to be included or replaced in the response headers. Response headers are
+identified with the "stub.res." prefix and may refer to standard HTTP headers or custom proprietary ones:
+
+`stub.res.Server` type: String, value: Stubway/1.0.0 <-- this property will include the `Server` HTTP header in the
+response. The value of the header will be `Stubway/1.0.0`.
+
 ![add_resource node](docs/demo/get-fantasy.png)
 
 Save the changes.

--- a/core/src/main/java/io/wttech/stubway/StubConstants.java
+++ b/core/src/main/java/io/wttech/stubway/StubConstants.java
@@ -8,7 +8,7 @@ public class StubConstants {
 	public static final String STATUS_CODE = NAMESPACE + "statusCode";
 	public static final String METHOD = NAMESPACE + "method";
 	public static final String REGEX_SUFFIX = ".regex";
-	public static final String RESPONSE_PREFIX = "response.";
+	public static final String RESPONSE_PREFIX = NAMESPACE + "res.";
 
 	private StubConstants() {
 		throw new IllegalStateException("Utility class");

--- a/core/src/main/java/io/wttech/stubway/StubConstants.java
+++ b/core/src/main/java/io/wttech/stubway/StubConstants.java
@@ -1,7 +1,5 @@
 package io.wttech.stubway;
 
-import java.util.regex.Pattern;
-
 public class StubConstants {
 
 	public static final String STUB_RESOURCE_TYPE = "stubway/stub";
@@ -10,6 +8,7 @@ public class StubConstants {
 	public static final String STATUS_CODE = NAMESPACE + "statusCode";
 	public static final String METHOD = NAMESPACE + "method";
 	public static final String REGEX_SUFFIX = ".regex";
+	public static final String RESPONSE_PREFIX = "response.";
 
 	private StubConstants() {
 		throw new IllegalStateException("Utility class");

--- a/core/src/main/java/io/wttech/stubway/StubServlet.java
+++ b/core/src/main/java/io/wttech/stubway/StubServlet.java
@@ -1,6 +1,9 @@
 package io.wttech.stubway;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.Servlet;
 
@@ -44,6 +47,10 @@ public class StubServlet extends SlingAllMethodsServlet {
 
 		StubResponse stubResponse = stubFinderService.getStubResponse(request);
 		response.setStatus(stubResponse.getStatusCode());
+
+		Map<String, String> headers = Optional.ofNullable(stubResponse.getResponseHeaders()).orElse(Collections.emptyMap());
+		headers.keySet().forEach(k -> response.addHeader(k, headers.get(k)));
+
 		IOUtils.copy(stubResponse.getInputStream(), response.getOutputStream());
 	}
 

--- a/core/src/main/java/io/wttech/stubway/StubServlet.java
+++ b/core/src/main/java/io/wttech/stubway/StubServlet.java
@@ -49,7 +49,7 @@ public class StubServlet extends SlingAllMethodsServlet {
 		response.setStatus(stubResponse.getStatusCode());
 
 		Map<String, String> headers = Optional.ofNullable(stubResponse.getResponseHeaders()).orElse(Collections.emptyMap());
-		headers.keySet().forEach(k -> response.addHeader(k, headers.get(k)));
+		headers.keySet().forEach(k -> response.setHeader(k, headers.get(k)));
 
 		IOUtils.copy(stubResponse.getInputStream(), response.getOutputStream());
 	}

--- a/core/src/main/java/io/wttech/stubway/response/StubResponse.java
+++ b/core/src/main/java/io/wttech/stubway/response/StubResponse.java
@@ -2,6 +2,7 @@ package io.wttech.stubway.response;
 
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.Map;
 import java.util.Optional;
 
 import io.wttech.stubway.stub.Stub;
@@ -16,6 +17,7 @@ public class StubResponse {
 
 	private InputStream inputStream;
 	private int statusCode;
+	private Map<String, String> responseHeaders;
 
 	private static Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
@@ -39,6 +41,7 @@ public class StubResponse {
 		this.inputStream = Optional.ofNullable(foundStub.getInputStream())
 				.orElse(IOUtils.toInputStream("", Charset.defaultCharset()));
 		this.statusCode = foundStub.getStatusCode();
+		this.responseHeaders = foundStub.getResponseHeaders();
 	}
 
 	private StubResponse() {
@@ -62,5 +65,7 @@ public class StubResponse {
 	public int getStatusCode() {
 		return statusCode;
 	}
+
+	public Map<String, String> getResponseHeaders() { return responseHeaders; }
 
 }

--- a/core/src/main/java/io/wttech/stubway/stub/Stub.java
+++ b/core/src/main/java/io/wttech/stubway/stub/Stub.java
@@ -49,7 +49,6 @@ public class Stub {
 		this.stubProperties = valueMap.keySet().stream()
 				.filter(key -> !key.startsWith(StubConstants.JCR_NAMESPACE))
 				.filter(key -> !key.startsWith(StubConstants.NAMESPACE))
-				.filter(key -> !key.startsWith(StubConstants.RESPONSE_PREFIX))
 				.map(key -> StubProperty.create(key, valueMap.get(key, String[].class))).flatMap(Collection::stream)
 				.collect(Collectors.toSet());
 

--- a/stubway.tests/src/test/java/io/wttech/stubway/StubTests.java
+++ b/stubway.tests/src/test/java/io/wttech/stubway/StubTests.java
@@ -74,6 +74,7 @@ public class StubTests {
 		Response response = sendGetRequest("/content/stubway/stubs/library/books?type=fantasy");
 		response.then().statusCode(200);
 		compareHeader("Server", "Stubway/1.0.0", response);
+		compareHeader("Date", "Tue, 30 Feb 2022 25:65:73 GMT", response);
 		compareJsonResponse("fantasy_get.json", response);
 	}
 

--- a/stubway.tests/src/test/java/io/wttech/stubway/StubTests.java
+++ b/stubway.tests/src/test/java/io/wttech/stubway/StubTests.java
@@ -49,6 +49,10 @@ public class StubTests {
 		Assert.assertEquals(expected, actual);
 	}
 
+	private void compareHeader(String key, String value, Response response) {
+		Assert.assertEquals(value, response.getHeader(key));
+	}
+
 	private String getJsonFile(String fileName) throws IOException {
 		String json = IOUtils.toString(this.getClass().getResourceAsStream(fileName), "UTF-8");
 		return json;
@@ -69,6 +73,7 @@ public class StubTests {
 	public void getFantasyBooksTest() throws IOException {
 		Response response = sendGetRequest("/content/stubway/stubs/library/books?type=fantasy");
 		response.then().statusCode(200);
+		compareHeader("Server", "Stubway/1.0.0", response);
 		compareJsonResponse("fantasy_get.json", response);
 	}
 

--- a/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-fantasy.json.dir/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-fantasy.json.dir/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
 	xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:mixinTypes="[cq:ComponentMixin]" jcr:primaryType="nt:file"
-	type="fantasy" stub.method="GET">
+	type="fantasy" response.Server="Stubway/1.0.0" stub.method="GET">
 	<jcr:content jcr:lastModifiedBy="Administrator" jcr:primaryType="nt:resource" />
 </jcr:root>

--- a/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-fantasy.json.dir/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/stubway/stubs/library/books/get-fantasy.json.dir/.content.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
 	xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:mixinTypes="[cq:ComponentMixin]" jcr:primaryType="nt:file"
-	type="fantasy" response.Server="Stubway/1.0.0" stub.method="GET">
+	type="fantasy" stub.res.Server="Stubway/1.0.0" stub.res.Date="Tue, 30 Feb 2022 25:65:73 GMT" stub.method="GET">
 	<jcr:content jcr:lastModifiedBy="Administrator" jcr:primaryType="nt:resource" />
 </jcr:root>


### PR DESCRIPTION
Issue : #15

## Description
- Response headers must be specified with "response." prefix
- Ignore response headers when creating stub properties
- Gather response headers in a map, extracting the prefix
- Inject response headers in final HTTP response

## Types of Changes
- New feature
- Documentation / non-code

## Tasks
- [ ] Documentation
- [ ] Test cases

## Review
- [ ] Tests

## Deployment Notes
N/A